### PR TITLE
Simplify cache implementation and usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ authors = ["Adrian Perez de Castro <aperez@igalia.com>"]
 name = "popsicle"
 version = "0.1.0"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [dependencies]
 blake2-rfc = "^0.2"
 env_logger = "^0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,13 +168,8 @@ fn run() -> Result<()> {
     let true_path = util::find_program("true", None)
         .chain_err(|| "cannot find \"true\" executable")?;
 
-    let mut cache: Box<cache::Cache> = match cache::XdgCache::new(name.as_str()) {
-        Ok(cache) => Box::new(cache),
-        Err(err) => {
-            warn!("Cannot use XDG cache: {}", err);
-            Box::new(cache::DummyCache::new())
-        }
-    };
+    let mut cache = cache::Cache::new(name.as_str())
+        .chain_err(|| "Could not open cache")?;
     info!("cache: {:?}", cache);
 
     let old_version = cache.get("compiler-version")?;


### PR DESCRIPTION
In practice the only supported operation mode is using an actual cache directory, so there is not much of a point of keeping a trait plus two implementations of it, where one is never used.

This removes `DummyCache`, the `Cache` trait, and renames `XdgCache` as `Cache`. Also `Cache.has()` is only used for tests, therefore a `#[cfg(test)]` guard was added to it, and may be removed later if needed.

Closes #4 as there is no longer a fallback cache mechanism.