### PR TITLE
Calculate checksum over the whole generated tarball

### DIFF
--- a/src/csum.rs
+++ b/src/csum.rs
@@ -1,0 +1,80 @@
+//
+// csum.rs
+// Copyright (C) 2017 Adrian Perez <aperez@igalia.com>
+// Distributed under terms of the MIT license.
+//
+
+use std::convert::{ AsRef, From };
+use std::fmt::Write as FmtWrite;
+use std::io::{ Result as IOResult, Write };
+
+use super::blake2_rfc::blake2b::{ Blake2b, Blake2bResult };
+
+
+#[derive(Eq, PartialEq)]
+pub struct Checksum {
+    result: Blake2bResult,
+    hexstr: String,
+}
+
+impl From<Blake2bResult> for Checksum
+{
+    fn from(result: Blake2bResult) -> Self {
+        let mut hexstr = String::new();
+        for byte in result.as_bytes() {
+            write!(hexstr, "{:02x}", byte).unwrap();
+        }
+        Self {
+            result: result,
+            hexstr: hexstr,
+        }
+    }
+}
+
+impl AsRef<String> for Checksum {
+    fn as_ref(&self) -> &String {
+        &self.hexstr
+    }
+}
+
+impl AsRef<str> for Checksum {
+    fn as_ref(&self) -> &str {
+        self.hexstr.as_ref()
+    }
+}
+
+impl AsRef<[u8]> for Checksum {
+    fn as_ref(&self) -> &[u8] {
+        self.result.as_bytes()
+    }
+}
+
+
+pub struct CSumWriter<W: Write> {
+    inner: W,
+    csum: Blake2b,
+}
+
+impl<W: Write> CSumWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner: inner,
+            csum: Blake2b::new(64),
+        }
+    }
+
+    pub fn into_inner(self) -> (W, Checksum) {
+        (self.inner, self.csum.finalize().into())
+    }
+}
+
+impl<W: Write> Write for CSumWriter<W> {
+    fn flush(&mut self) -> IOResult<()> {
+        self.inner.flush()
+    }
+
+    fn write(&mut self, data: &[u8]) -> IOResult<usize> {
+        self.csum.write(data)?;
+        self.inner.write(data)
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,14 +5,10 @@
 //
 
 use std::convert::AsRef;
-use std::fmt::{ self, Write };
 use std::os::unix::prelude::MetadataExt;
 use std::path::{ Path, PathBuf };
 use std::process::Command;
 use regex::Regex;
-
-use super::blake2_rfc::blake2s;
-
 use errors::*;
 
 
@@ -86,55 +82,4 @@ pub fn find_program<P: AsRef<Path>>(name: P, symlink_target: Option<&PathBuf>) -
         }
     }
     bail!(ErrorKind::ExternalExeError(name_path.to_path_buf()))
-}
-
-
-#[derive(Eq, PartialEq)]
-pub struct Checksum {
-    result: blake2s::Blake2sResult,
-    hexstr: String,
-}
-
-pub struct Checksummer(blake2s::Blake2s);
-
-impl Checksummer {
-    #[inline]
-    pub fn new() -> Self {
-        Checksummer(blake2s::Blake2s::new(32))
-    }
-
-    #[inline]
-    pub fn update(&mut self, data: &[u8]) {
-        self.0.update(data)
-    }
-
-    #[inline]
-    pub fn finalize(self) -> Checksum {
-        Checksum::from_result(self.0.finalize())
-    }
-}
-
-impl Checksum {
-    #[inline]
-    fn from_result(result: blake2s::Blake2sResult) -> Self {
-        let mut hexstr = String::new();
-        for byte in result.as_bytes() {
-            write!(hexstr, "{:02x}", byte).unwrap();
-        }
-        Checksum {
-            result: result,
-            hexstr: hexstr,
-        }
-    }
-
-    #[inline]
-    pub fn as_string(&self) -> &String {
-        &self.hexstr
-    }
-}
-
-impl fmt::LowerHex for Checksum {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.hexstr)
-    }
 }


### PR DESCRIPTION
This shifts the responsibility of checksum calculation from `bindep::Solver` to a separate `csum::CSumWriter` which implements `std::io::Write`, keeps a `Blake2b` updated and relays writes to something else which implements `Write`.

The `bindep::Solver` gets passed a `CSumWriter`, so all that it writes to the Tar file (headers, attributes, etc. and not only file contents) ends up being part of the checksum.

Fixes #1