### PR TITLE
Only build support for ELF binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ pretty_assertions = "*"
 blake2-rfc = "^0.2"
 env_logger = "^0.4"
 error-chain = "^0.11"
-goblin = "^0.0"
 lazy_static = "^0.2"
 libflate = "^0.1"
 log = "^0.3"
@@ -22,5 +21,14 @@ structopt-derive = "^0.1"
 tar = "^0.4"
 xdg = "^2.0"
 
+[dependencies.goblin]
+version = "^0.0"
+default-features = false
+features = ["std", "endian_fd"]
+
 [profile.release]
 lto = true
+
+[features]
+default = ["elf"]
+elf = ["goblin/elf32", "goblin/elf64"]


### PR DESCRIPTION
Currently Popsicle has support only for ELF binaries, and support for other executable formats is marked as unimplemented. It seems like a better option to build Goblin only with support for ELF binaries, and use `goblin::elf::*` directly. This shaves ~300 KiB in x86-64 in release mode after stripping with `strip -x --strip-unneeded`.